### PR TITLE
Remove NSRTPROFILE tracking and enforce Coffee profile on upgrade

### DIFF
--- a/Core/Versions.lua
+++ b/Core/Versions.lua
@@ -5,7 +5,7 @@ local LibSerialize = LibStub("LibSerialize")
 local LibDeflate = LibStub("LibDeflate")
 
 ---@alias AddonShortcode "CRT" | "BW" | "NSRT" | "RCLC"
----@alias TrackedShortcode AddonShortcode | "NSRTHASH" | "NSRTPROFILE"
+---@alias TrackedShortcode AddonShortcode | "NSRTHASH"
 
 local BROADCAST_INTERVAL = 3
 
@@ -105,20 +105,6 @@ local function GetNSRTNoteHash()
     return "NONE"
 end
 
-local function GetNSRTProfileName()
-    if not C_AddOns.IsAddOnLoaded("NorthernSkyRaidTools") then
-        return "NONE"
-    end
-    if type(NSRT) ~= "table" or type(NSRT.Profiles) ~= "table" then
-        return "NONE"
-    end
-    local name = NSRT.CurrentProfile
-    if type(name) ~= "string" or name == "" then
-        return "NONE"
-    end
-    return name
-end
-
 local function GetAddonVersion(name)
     if C_AddOns.IsAddOnLoaded(name) then
         return C_AddOns.GetAddOnMetadata(name, "Version") or "NONE"
@@ -151,7 +137,6 @@ local function CollectLocalVersionTable()
 
     -- hash notes
     versions["NSRTHASH"] = GetNSRTNoteHash()
-    versions["NSRTPROFILE"] = GetNSRTProfileName()
 
     return versions
 end
@@ -368,7 +353,6 @@ end
 
 Private.StringHash = StringHash
 Private.GetNSRTNoteHash = GetNSRTNoteHash
-Private.GetNSRTProfileName = GetNSRTProfileName
 Private.GetAddonVersion = GetAddonVersion
 Private.CollectLocalVersionTable = CollectLocalVersionTable
 Private.EncodeMessage = EncodeMessage

--- a/Features/ForceAddonSettings.lua
+++ b/Features/ForceAddonSettings.lua
@@ -274,6 +274,14 @@ frame:SetScript("OnEvent", function(self, event, addonName)
         self:UnregisterEvent("ADDON_LOADED")
         self:UnregisterEvent("PLAYER_LOGIN")
 
+        -- Re-run after NSRT's own init finishes: pre-profile NSRT upgrades
+        -- haven't populated NSRT.Profiles by our ADDON_LOADED handler, so
+        -- the Coffee profile can't be created until NSRT bootstraps it here.
+        C_Timer.After(0, function()
+            EnforceNSRT()
+            Private:InvalidateLocalVersions()
+        end)
+
         -- Disable TimelineReminders if it is still enabled
         if C_AddOns.GetAddOnEnableState("TimelineReminders") > 0 then
             C_AddOns.DisableAddOn("TimelineReminders")

--- a/Interface/Tabs/Raid.lua
+++ b/Interface/Tabs/Raid.lua
@@ -55,11 +55,6 @@ local function GeneratePlayerStatus(playerVersions, expectedVersions)
         table.insert(failures, "NSRTNOTE")
     end
 
-    local playerProfile = playerVersions["NSRTPROFILE"]
-    if playerProfile and playerProfile ~= "NONE" and playerProfile ~= Private.COFFEE_PROFILE then
-        table.insert(failures, "NSRTPROFILE=" .. playerProfile)
-    end
-
     return { good = #failures == 0, failures = failures, noResponse = false }
 end
 
@@ -87,7 +82,6 @@ local function GenerateTooltipText(playerVersions)
     end
 
     table.insert(entries, "NSRTHASH=" .. (playerVersions["NSRTHASH"] or "NONE"))
-    table.insert(entries, "NSRTPROFILE=" .. (playerVersions["NSRTPROFILE"] or "NONE"))
 
     return table.concat(entries, "\n")
 end
@@ -169,10 +163,8 @@ local function GenerateMockPlayerData(expectedVersions, allGood)
 
         if scenario == 1 then
             playerVersions["NSRTHASH"] = expectedVersions["NSRTHASH"]
-            playerVersions["NSRTPROFILE"] = Private.COFFEE_PROFILE
         else
             playerVersions["NSRTHASH"] = math.random() > 0.6 and expectedVersions["NSRTHASH"] or "different_hash"
-            playerVersions["NSRTPROFILE"] = math.random() > 0.6 and Private.COFFEE_PROFILE or "default"
         end
 
         table.insert(players, { name = playerName, versions = playerVersions })

--- a/spec/ForceAddonSettings_spec.lua
+++ b/spec/ForceAddonSettings_spec.lua
@@ -409,7 +409,6 @@ describe("ForceAddonSettings", function()
 
             assert.are.equal("Coffee", NSRT.CurrentProfile)
             assert.is_not_nil(NSRT.Profiles.Coffee)
-            assert.are.equal("Coffee", Private.GetNSRTProfileName())
         end)
     end)
 

--- a/spec/ForceAddonSettings_spec.lua
+++ b/spec/ForceAddonSettings_spec.lua
@@ -318,6 +318,101 @@ describe("ForceAddonSettings", function()
         end)
     end)
 
+    describe("pre-profile -> profile NSRT upgrade", function()
+        -- Minimal mirror of the vendor NSRT LoadMyProfile / CreateProfile flow
+        -- needed to exercise the ADDON_LOADED -> NSRT init -> re-enforce path.
+        local NSI_ignored = {
+            Profiles = true,
+            ProfileKeys = true,
+            CurrentProfile = true,
+            MainProfile = true,
+        }
+
+        local function NSI_SaveProfile()
+            if NSRT.CurrentProfile then
+                NSRT.Profiles[NSRT.CurrentProfile] = {}
+                for k, v in pairs(NSRT) do
+                    if not NSI_ignored[k] then
+                        NSRT.Profiles[NSRT.CurrentProfile][k] = type(v) == "table" and CopyTable(v) or v
+                    end
+                end
+            end
+        end
+
+        local function NSI_AddMissingDefaults()
+            if NSRT.Profiles == nil then
+                NSRT.Profiles = {}
+            end
+            if NSRT.ProfileKeys == nil then
+                NSRT.ProfileKeys = {}
+            end
+            if NSRT.CurrentProfile == nil then
+                NSRT.CurrentProfile = "default"
+            end
+            if NSRT.MainProfile == nil then
+                NSRT.MainProfile = "default"
+            end
+        end
+
+        local function NSI_LoadMyProfile()
+            NSI_AddMissingDefaults()
+            local ProfileToLoad = "default"
+            local key = "Tester-TestRealm"
+            if NSRT.ProfileKeys[key] then
+                ProfileToLoad = NSRT.ProfileKeys[key]
+            elseif NSRT.MainProfile then
+                ProfileToLoad = NSRT.MainProfile
+            end
+            if NSRT.Profiles[ProfileToLoad] then
+                for k, v in pairs(NSRT.Profiles[ProfileToLoad]) do
+                    if not NSI_ignored[k] then
+                        NSRT[k] = type(v) == "table" and CopyTable(v) or v
+                    end
+                end
+                NSRT.ProfileKeys[key] = ProfileToLoad
+                NSRT.CurrentProfile = ProfileToLoad
+            else
+                NSRT.Profiles[ProfileToLoad] = {}
+                NSI_SaveProfile()
+                NSRT.ProfileKeys[key] = ProfileToLoad
+                NSRT.CurrentProfile = ProfileToLoad
+                NSI_SaveProfile()
+            end
+        end
+
+        it("migrates the player onto Coffee when NSRT.Profiles is populated after ADDON_LOADED", function()
+            Replace(C_AddOns, "IsAddOnLoaded", function()
+                return true
+            end)
+            Replace("BNGetInfo", function()
+                return nil, nil
+            end)
+            -- Saved NSRT predates the Profiles feature.
+            Replace("NSRT", {
+                ReadyCheckSettings = { RaidBuffCheck = false },
+                NickNames = { ["Someone-Realm"] = "Some" },
+            })
+
+            -- Simulate CRT's ADDON_LOADED handler running first (takes
+            -- pre-profile path because NSRT.Profiles isn't set yet).
+            Private.EnforceNSRT()
+            assert.is_nil(NSRT.Profiles)
+
+            -- Simulate NSRT's ADDON_LOADED/PLAYER_LOGIN handler initializing
+            -- its profile system, which leaves the player on "default".
+            NSI_LoadMyProfile()
+            assert.are.equal("default", NSRT.CurrentProfile)
+
+            -- The deferred PLAYER_LOGIN re-enforcement should now pick up that
+            -- NSRT has Profiles and migrate the player to Coffee.
+            Private.EnforceNSRT()
+
+            assert.are.equal("Coffee", NSRT.CurrentProfile)
+            assert.is_not_nil(NSRT.Profiles.Coffee)
+            assert.are.equal("Coffee", Private.GetNSRTProfileName())
+        end)
+    end)
+
     describe("GetNSRTPlayerProfileKey", function()
         it("combines the character name and realm", function()
             Replace("UnitFullName", function()

--- a/spec/RaidStatus_spec.lua
+++ b/spec/RaidStatus_spec.lua
@@ -5,7 +5,6 @@ describe("RaidStatus", function()
         NSRT = "1.0",
         RCLC = "1.0",
         NSRTHASH = "def",
-        NSRTPROFILE = "Coffee",
     }
 
     describe("GeneratePlayerStatus", function()
@@ -16,7 +15,6 @@ describe("RaidStatus", function()
                 NSRT = "1.0",
                 RCLC = "1.0",
                 NSRTHASH = "def",
-                NSRTPROFILE = "Coffee",
             }
             local status = Private.GeneratePlayerStatus(player, baseExpected)
             assert.is_true(status.good)
@@ -37,7 +35,6 @@ describe("RaidStatus", function()
                 NSRT = "1.0",
                 RCLC = "1.0",
                 NSRTHASH = "def",
-                NSRTPROFILE = "Coffee",
             }
             local status = Private.GeneratePlayerStatus(player, baseExpected)
             assert.is_false(status.good)
@@ -52,7 +49,6 @@ describe("RaidStatus", function()
                 NSRT = "1.0",
                 RCLC = "1.0",
                 NSRTHASH = "def",
-                NSRTPROFILE = "Coffee",
             }
             local status = Private.GeneratePlayerStatus(player, baseExpected)
             assert.is_false(status.good)
@@ -66,7 +62,6 @@ describe("RaidStatus", function()
                 NSRT = "1.0",
                 RCLC = "1.0",
                 NSRTHASH = "def",
-                NSRTPROFILE = "Coffee",
             }
             local status = Private.GeneratePlayerStatus(player, baseExpected)
             assert.is_false(status.good)
@@ -80,38 +75,10 @@ describe("RaidStatus", function()
                 NSRT = "1.0",
                 RCLC = "1.0",
                 NSRTHASH = "different",
-                NSRTPROFILE = "Coffee",
             }
             local status = Private.GeneratePlayerStatus(player, baseExpected)
             assert.is_false(status.good)
             assert.are.equal("NSRTNOTE", status.failures[1])
-        end)
-
-        it("flags a non-Coffee NSRT profile", function()
-            local player = {
-                CRT = "1.0",
-                BW = "2.0",
-                NSRT = "1.0",
-                RCLC = "1.0",
-                NSRTHASH = "def",
-                NSRTPROFILE = "default",
-            }
-            local status = Private.GeneratePlayerStatus(player, baseExpected)
-            assert.is_false(status.good)
-            assert.are.equal("NSRTPROFILE=default", status.failures[1])
-        end)
-
-        it("does not flag NSRTPROFILE when the player reports NONE", function()
-            local player = {
-                CRT = "1.0",
-                BW = "2.0",
-                NSRT = "1.0",
-                RCLC = "1.0",
-                NSRTHASH = "def",
-                NSRTPROFILE = "NONE",
-            }
-            local status = Private.GeneratePlayerStatus(player, baseExpected)
-            assert.is_true(status.good)
         end)
     end)
 
@@ -150,13 +117,11 @@ describe("RaidStatus", function()
                 NSRT = "3.0",
                 RCLC = "5.0",
                 NSRTHASH = "def",
-                NSRTPROFILE = "Coffee",
             }
             local result = Private.GenerateTooltipText(player)
             assert.is_not_nil(result:find("CRT=1.0"))
             assert.is_not_nil(result:find("BW=2.0"))
             assert.is_not_nil(result:find("NSRTHASH=def"))
-            assert.is_not_nil(result:find("NSRTPROFILE=Coffee"))
         end)
 
         it("returns NO RESPONSE when player versions are nil", function()

--- a/spec/Versions_spec.lua
+++ b/spec/Versions_spec.lua
@@ -95,41 +95,8 @@ describe("Versions", function()
         end)
     end)
 
-    describe("GetNSRTProfileName", function()
-        it("returns NONE when NSRT is not loaded", function()
-            Replace(C_AddOns, "IsAddOnLoaded", function()
-                return false
-            end)
-            assert.are.equal("NONE", Private.GetNSRTProfileName())
-        end)
-
-        it("returns NONE on pre-profile NSRT", function()
-            Replace(C_AddOns, "IsAddOnLoaded", function()
-                return true
-            end)
-            Replace("NSRT", {})
-            assert.are.equal("NONE", Private.GetNSRTProfileName())
-        end)
-
-        it("returns the current profile name when set", function()
-            Replace(C_AddOns, "IsAddOnLoaded", function()
-                return true
-            end)
-            Replace("NSRT", { Profiles = {}, CurrentProfile = "Coffee" })
-            assert.are.equal("Coffee", Private.GetNSRTProfileName())
-        end)
-
-        it("returns NONE when CurrentProfile is empty", function()
-            Replace(C_AddOns, "IsAddOnLoaded", function()
-                return true
-            end)
-            Replace("NSRT", { Profiles = {}, CurrentProfile = "" })
-            assert.are.equal("NONE", Private.GetNSRTProfileName())
-        end)
-    end)
-
     describe("CollectLocalVersionTable", function()
-        it("includes every tracked shortcode, NSRTHASH, and NSRTPROFILE", function()
+        it("includes every tracked shortcode and NSRTHASH", function()
             Replace(C_AddOns, "IsAddOnLoaded", function()
                 return true
             end)
@@ -142,7 +109,6 @@ describe("Versions", function()
                 assert.is_not_nil(versions[addon.shortcode])
             end
             assert.is_not_nil(versions["NSRTHASH"])
-            assert.is_not_nil(versions["NSRTPROFILE"])
         end)
     end)
 


### PR DESCRIPTION
## Summary
This change removes NSRTPROFILE version tracking from raid status checks and implements automatic migration to the Coffee profile when upgrading from pre-profile NSRT versions.

## Key Changes

- **Removed NSRTPROFILE tracking**: Eliminated `GetNSRTProfileName()` function and all references to NSRTPROFILE in version collection and raid status validation. Players are no longer flagged for using non-Coffee profiles.

- **Added deferred NSRT enforcement**: Implemented a deferred re-enforcement of NSRT settings after NSRT's own initialization completes. This handles the upgrade path where pre-profile NSRT saves don't have `NSRT.Profiles` populated until NSRT's ADDON_LOADED/PLAYER_LOGIN handlers run.

- **Automatic Coffee profile migration**: When upgrading from pre-profile NSRT, the deferred enforcement now detects that `NSRT.Profiles` has been initialized and automatically migrates the player to the Coffee profile, creating it if necessary.

## Implementation Details

- The deferred enforcement uses `C_Timer.After(0, ...)` to run after NSRT's initialization completes, ensuring `NSRT.Profiles` is available before attempting profile operations.

- Added comprehensive test coverage for the pre-profile to profile upgrade scenario, including a minimal mirror of NSRT's profile loading/saving flow to exercise the upgrade path.

- Removed all NSRTPROFILE-related test cases and assertions from raid status validation tests, as profile enforcement is now handled transparently during addon initialization rather than through version tracking.

https://claude.ai/code/session_017AFSTjMFoPJoVF9nECo2dG